### PR TITLE
Update case of binary in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-project_name: hashannotator
+project_name: HashAnnotator
 before:
   hooks:
     - go mod download
@@ -19,7 +19,7 @@ archives:
       386: i386
       amd64: x86_64
   - id: latest
-    name_template: '{{ .ProjectName }}_latest_{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ tolower .ProjectName }}_latest_{{ .Os }}_{{ .Arch }}'
     replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
We hit an issue when attempting to use this plugin as installed from the
GitHub release archive. It appears that Kustomize expects the case of
the plugin's binary to match the `Kind` in the hashannotator object.
This change updates the goreleaser.yaml file to create a binary with the
correct tense.